### PR TITLE
Port away from KWin plugin loading using keyword which has been removed

### DIFF
--- a/breezedecoration.cpp
+++ b/breezedecoration.cpp
@@ -56,8 +56,8 @@ K_PLUGIN_FACTORY_WITH_JSON(
     BreezeSierraDecoFactory,
     "breeze.json",
     registerPlugin<SierraBreeze::Decoration>();
-    registerPlugin<SierraBreeze::Button>(QStringLiteral("button"));
-    registerPlugin<SierraBreeze::ConfigWidget>(QStringLiteral("kcmodule"));
+    registerPlugin<SierraBreeze::Button>();
+    registerPlugin<SierraBreeze::ConfigWidget>();
 )
 
 namespace SierraBreeze


### PR DESCRIPTION
Since KWin 5.23 this is deprecated. In 5.25 the feature got removed.
See https://invent.kde.org/plasma/kwin/-/merge_requests/1854/diffs

Also, this fixes the porting away from the deprecated KCoreAddons API.